### PR TITLE
V1.0.5.0

### DIFF
--- a/SinTachiePlugin/Parts/PartBlock.cs
+++ b/SinTachiePlugin/Parts/PartBlock.cs
@@ -12,7 +12,6 @@ using System.Windows;
 using System.Windows.Shapes;
 using Vortice.Direct2D1;
 using YukkuriMovieMaker.Commons;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 using Path = System.IO.Path;
 
 namespace SinTachiePlugin.Parts
@@ -147,7 +146,7 @@ namespace SinTachiePlugin.Parts
         }
 
         public static JsonSerializerSettings GetJsonSetting =>
-            new JsonSerializerSettings
+            new()
             {
                 TypeNameHandling = TypeNameHandling.Auto
             };
@@ -165,7 +164,7 @@ namespace SinTachiePlugin.Parts
                     {
                         using (var sr = new StreamReader(stream))
                         {
-                            
+
                             if (JsonConvert.DeserializeObject<PartInfo>(sr.ReadToEnd(), GetJsonSetting) is PartInfo info)
                             {
                                 return info;

--- a/SinTachiePlugin/Parts/PartBlock.cs
+++ b/SinTachiePlugin/Parts/PartBlock.cs
@@ -146,7 +146,7 @@ namespace SinTachiePlugin.Parts
             ShowInformation($"デフォルト値を{str}しました。");
         }
 
-        private static JsonSerializerSettings GetJsonSetting =>
+        public static JsonSerializerSettings GetJsonSetting =>
             new JsonSerializerSettings
             {
                 TypeNameHandling = TypeNameHandling.Auto

--- a/SinTachiePlugin/Parts/PartBlockUI.xaml
+++ b/SinTachiePlugin/Parts/PartBlockUI.xaml
@@ -7,7 +7,7 @@
              xmlns:c="clr-namespace:YukkuriMovieMaker.Controls;assembly=YukkuriMovieMaker.Controls"
              d:DataContext="{d:DesignInstance Type=local:PartBlock}"
              mc:Ignorable="d">
-    <Grid MouseRightButtonUp="Grid_MouseRightButtonUp">
+    <Grid>
         <Border BorderBrush="#FF808080" BorderThickness="1">
             <StackPanel Margin="4,4,4,4" Orientation="Vertical">
                 <WrapPanel>

--- a/SinTachiePlugin/Parts/PartBlockUI.xaml
+++ b/SinTachiePlugin/Parts/PartBlockUI.xaml
@@ -7,7 +7,7 @@
              xmlns:c="clr-namespace:YukkuriMovieMaker.Controls;assembly=YukkuriMovieMaker.Controls"
              d:DataContext="{d:DesignInstance Type=local:PartBlock}"
              mc:Ignorable="d">
-    <Grid>
+    <Grid MouseRightButtonUp="Grid_MouseRightButtonUp">
         <Border BorderBrush="#FF808080" BorderThickness="1">
             <StackPanel Margin="4,4,4,4" Orientation="Vertical">
                 <WrapPanel>

--- a/SinTachiePlugin/Parts/PartBlockUI.xaml.cs
+++ b/SinTachiePlugin/Parts/PartBlockUI.xaml.cs
@@ -23,6 +23,7 @@ namespace SinTachiePlugin.Parts
     {
         public event EventHandler? BeginEdit;
         public event EventHandler? EndEdit;
+        public event EventHandler? RightMouseButtonUp;
 
         public PartBlockUI()
         {
@@ -41,17 +42,19 @@ namespace SinTachiePlugin.Parts
         {
             //Part内のAnimationを変更した際にPartsを更新する
             //複数のアイテムを選択している場合にすべてのアイテムを更新するために必要
-            var vm = DataContext as PartsListControllerViewModel;
-            vm?.CopyToOtherItems();
+            var vm = DataContext as PartBlock;
             EndEdit?.Invoke(this, e);
         }
 
         private void Update_CheckBox(object sender, RoutedEventArgs e)
         {
             BeginEdit?.Invoke(this, e);
-            var vm = DataContext as PartsListControllerViewModel;
-            vm?.CopyToOtherItems();
             EndEdit?.Invoke(this, e);
+        }
+
+        private void Grid_MouseRightButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            RightMouseButtonUp?.Invoke(this, e);
         }
     }
 }

--- a/SinTachiePlugin/Parts/PartBlockUI.xaml.cs
+++ b/SinTachiePlugin/Parts/PartBlockUI.xaml.cs
@@ -23,7 +23,6 @@ namespace SinTachiePlugin.Parts
     {
         public event EventHandler? BeginEdit;
         public event EventHandler? EndEdit;
-        public event EventHandler? RightMouseButtonUp;
 
         public PartBlockUI()
         {
@@ -50,11 +49,6 @@ namespace SinTachiePlugin.Parts
         {
             BeginEdit?.Invoke(this, e);
             EndEdit?.Invoke(this, e);
-        }
-
-        private void Grid_MouseRightButtonUp(object sender, MouseButtonEventArgs e)
-        {
-            RightMouseButtonUp?.Invoke(this, e);
         }
     }
 }

--- a/SinTachiePlugin/Parts/PartNode.cs
+++ b/SinTachiePlugin/Parts/PartNode.cs
@@ -56,10 +56,10 @@ namespace SinTachiePlugin.Parts
         public double Exp_X { get; set; }
         public double Exp_Y { get; set; }
         //public ImmutableList<IVideoEffectProcessor> Processors { get; set; } = [];
-        public DrawDescription DrawDescription { get; set; } = new(
-                new Vector3(), new Vector2(), new Vector2(), new Vector3(), Matrix4x4.Identity,
-                new InterpolationMode(), 1.0, false, []
-                );
+        //public DrawDescription DrawDescription { get; set; } = new(
+        //        new Vector3(), new Vector2(), new Vector2(), new Vector3(), Matrix4x4.Identity,
+        //        new InterpolationMode(), 1.0, false, []
+        //        );
 
         public Vector2 Shift { get; set; }
         public float Opacity2 { get; set; }

--- a/SinTachiePlugin/Parts/PartsListController.xaml
+++ b/SinTachiePlugin/Parts/PartsListController.xaml
@@ -19,24 +19,22 @@
                 <ColumnDefinition Width="26"/>
             </Grid.ColumnDefinitions>
             <ListBox Grid.Column="0" HorizontalContentAlignment="Stretch" ItemsSource="{Binding Parts}" SelectedIndex="{Binding SelectedPartIndex}"
-                     Name="list" ScrollViewer.CanContentScroll="False"  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                     MouseRightButtonUp="list_MouseRightButtonUp">
+                     Name="list" ScrollViewer.CanContentScroll="False"  ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
-                        <local:PartBlockUI BeginEdit="PropertiesEditor_BeginEdit" EndEdit="PropertiesEditor_EndEdit" RightMouseButtonUp="PartBlockUI_RightMouseButtonUp"/>
+                        <local:PartBlockUI BeginEdit="PropertiesEditor_BeginEdit" EndEdit="PropertiesEditor_EndEdit"/>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
+                <ListBox.ContextMenu>
+                    <ContextMenu IsOpen="{Binding ContextMenuIsOpen}">
+                        <MenuItem Header="切り取り" IsEnabled="{Binding SomeBlockSelected}" Click ="Scissors_Clicked"/>
+                        <MenuItem Header="コピー" IsEnabled="{Binding SomeBlockSelected}" Click="Copy_Clicked"/>
+                        <MenuItem Header="貼り付け" IsEnabled="{Binding PasteEnable}" Click="Paste_Clicked"/>
+                        <MenuItem Header="複製" IsEnabled="{Binding SomeBlockSelected}" Click="Duplication_Clicked"/>
+                        <MenuItem Header="削除" IsEnabled="{Binding SomeBlockSelected}" Click="Remove_Clicked"/>
+                    </ContextMenu>
+                </ListBox.ContextMenu>
             </ListBox>
-
-            <Popup IsOpen="{Binding EditPopupIsOpen}" Placement="MousePoint"  StaysOpen="False" Panel.ZIndex="100" >
-                <ListBox SelectedIndex="{Binding BottunIndex}">
-                    <ListBoxItem Content="切り取り" IsEnabled="{Binding ScissorsEnable}" Selected="Scissors_Selected"/>
-                    <ListBoxItem Content="コピー" IsEnabled="{Binding CopyEnable}" Selected="Copy_Selected"/>
-                    <ListBoxItem Content="貼り付け" IsEnabled="{Binding PasteEnable}" Selected="Paste_Selected"/>
-                    <ListBoxItem Content="複製" IsEnabled="{Binding DuplicationEnable}" Selected="Duplication_Selected"/>
-                    <ListBoxItem Content="削除" IsEnabled="{Binding RemoveEnable}" Selected="Remove_Selected"/>
-                </ListBox>
-            </Popup>
             <Grid Grid.Column="1">
                 <Grid>
                     <Grid.RowDefinitions>

--- a/SinTachiePlugin/Parts/PartsListController.xaml
+++ b/SinTachiePlugin/Parts/PartsListController.xaml
@@ -18,15 +18,25 @@
                 <ColumnDefinition />
                 <ColumnDefinition Width="26"/>
             </Grid.ColumnDefinitions>
-            <ListBox Grid.Column="0" HorizontalContentAlignment="Stretch" ItemsSource="{Binding Parts}" SelectedIndex="{Binding SelectedIndex}"
-                     Name="list" ScrollViewer.CanContentScroll="False"  ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+            <ListBox Grid.Column="0" HorizontalContentAlignment="Stretch" ItemsSource="{Binding Parts}" SelectedIndex="{Binding SelectedPartIndex}"
+                     Name="list" ScrollViewer.CanContentScroll="False"  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                     MouseRightButtonUp="list_MouseRightButtonUp">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
-                        <local:PartBlockUI BeginEdit="PropertiesEditor_BeginEdit" EndEdit="PropertiesEditor_EndEdit"/>
+                        <local:PartBlockUI BeginEdit="PropertiesEditor_BeginEdit" EndEdit="PropertiesEditor_EndEdit" RightMouseButtonUp="PartBlockUI_RightMouseButtonUp"/>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>
 
+            <Popup IsOpen="{Binding EditPopupIsOpen}" Placement="MousePoint"  StaysOpen="False" Panel.ZIndex="100" >
+                <ListBox SelectedIndex="{Binding BottunIndex}">
+                    <ListBoxItem Content="切り取り" IsEnabled="{Binding ScissorsEnable}" Selected="Scissors_Selected"/>
+                    <ListBoxItem Content="コピー" IsEnabled="{Binding CopyEnable}" Selected="Copy_Selected"/>
+                    <ListBoxItem Content="貼り付け" IsEnabled="{Binding PasteEnable}" Selected="Paste_Selected"/>
+                    <ListBoxItem Content="複製" IsEnabled="{Binding DuplicationEnable}" Selected="Duplication_Selected"/>
+                    <ListBoxItem Content="削除" IsEnabled="{Binding RemoveEnable}" Selected="Remove_Selected"/>
+                </ListBox>
+            </Popup>
             <Grid Grid.Column="1">
                 <Grid>
                     <Grid.RowDefinitions>
@@ -34,16 +44,14 @@
                         <RowDefinition Height="26"/>
                         <RowDefinition Height="26"/>
                         <RowDefinition Height="26"/>
-                        <RowDefinition Height="26"/>
                     </Grid.RowDefinitions>
                     <Button Grid.Row="0" Content="╋" Command="{Binding AddCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" ToolTip="「追加するパーツ」で選択している名前のパーツが追加されます。"/>
                     <Button Grid.Row="1" Content="━" Command="{Binding RemoveCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" ToolTip="選択されているパーツを取り除きます。"/>
-                    <Button Grid.Row="2" Content="複" Command="{Binding DuplicationCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" ToolTip="選択されているパーツを複製します。"/>
-                    <Button Grid.Row="3" Content="▲" Command="{Binding MoveUpCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" ToolTip="選択されているパーツを一つ上のパーツと入れ替えます。"/>
-                    <Button Grid.Row="4" Content="▼" Command="{Binding MoveDownCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" ToolTip="選択されているパーツを一つ下のパーツと入れ替えます。"/>
+                    <Button Grid.Row="2" Content="▲" Command="{Binding MoveUpCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" ToolTip="選択されているパーツを一つ上のパーツと入れ替えます。"/>
+                    <Button Grid.Row="3" Content="▼" Command="{Binding MoveDownCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" ToolTip="選択されているパーツを一つ下のパーツと入れ替えます。"/>
                 </Grid>
-                <Popup IsOpen="{Binding PopupIsOpen}" Placement="Left" StaysOpen="False" VerticalAlignment="Top" >
-                    <ScrollViewer MaxHeight="300" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
+                <Popup IsOpen="{Binding PartsPopupIsOpen}" Placement="Left" StaysOpen="False" VerticalAlignment="Top" >
+                    <ScrollViewer MaxHeight="300" MinWidth="100" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
                         <TreeView Panel.ZIndex="100" ItemsSource ="{Binding PartNameTree}" SelectedItemChanged="TreeView_SelectedItemChanged">
                             <TreeView.ItemTemplate>
                                 <HierarchicalDataTemplate ItemsSource="{Binding Children}">
@@ -55,6 +63,7 @@
                 </Popup>
             </Grid>
         </Grid>
+        
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="194"/>
@@ -68,27 +77,26 @@
                         <RowDefinition Height="26"/>
                     </Grid.RowDefinitions>
 
-                        <!-- 選択されたブロックのデフォルト値を編集するエリア -->
-                        <Label Grid.Row="0" Content="デフォルト設定" HorizontalAlignment="Left" Margin="4,4,0,0" VerticalAlignment="Top" Padding="0,0,0,0"/>
-                        <Grid Grid.Row="1" Margin="0,0,8,0">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition/>
-                                <ColumnDefinition/>
-                                <ColumnDefinition/>
-                            </Grid.ColumnDefinitions>
-                            <Button Grid.Column="0" Command="{Binding WriteDefaultCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" Content="保存" ToolTip="選択されているパーツが指定している画像ファイルに、現在のパーツパラメータ情報をデフォルトとして記録します。&#xa;(stpiファイルが生成されます。)"/>
-                            <Button Grid.Column="1" Command="{Binding DeleteDefaultCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" Content="削除" ToolTip="選択されているパーツが指定している画像ファイルから、デフォルトのパラメータ情報を取り消します。&#xa;(stpiファイル自体は削除されません。)"/>
-                            <Button Grid.Column="2" Command="{Binding ReloadDefaultCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" Content="リロード" ToolTip="選択されているパーツが指定している画像ファイルから、デフォルトのパラメータ情報を読み取り、現在の全パラメータを自動編集します。"/>
-                        </Grid>
+                    <!-- 選択されたブロックのデフォルト値を編集するエリア -->
+                    <Label Grid.Row="0" Content="デフォルト設定" HorizontalAlignment="Left" Margin="4,4,0,0" VerticalAlignment="Top" Padding="0,0,0,0"/>
+                    <Grid Grid.Row="1" Margin="0,0,8,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition/>
+                            <ColumnDefinition/>
+                            <ColumnDefinition/>
+                        </Grid.ColumnDefinitions>
+                        <Button Grid.Column="0" Command="{Binding WriteDefaultCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" Content="保存" ToolTip="選択されているパーツが指定している画像ファイルに、現在のパーツパラメータ情報をデフォルトとして記録します。&#xa;(stpiファイルが生成されます。)"/>
+                        <Button Grid.Column="1" Command="{Binding DeleteDefaultCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" Content="削除" ToolTip="選択されているパーツが指定している画像ファイルから、デフォルトのパラメータ情報を取り消します。&#xa;(stpiファイル自体は削除されません。)"/>
+                        <Button Grid.Column="2" Command="{Binding ReloadDefaultCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" Content="リロード" ToolTip="選択されているパーツが指定している画像ファイルから、デフォルトのパラメータ情報を読み取り、現在の全パラメータを自動編集します。"/>
                     </Grid>
                 </Grid>
-            </WrapPanel>
+            </Grid>
         </Grid>
-        <c:PropertiesEditor 
+        <c:PropertiesEditor
             Grid.Row="2"
-            Target="{Binding ElementName=list,Path=SelectedValue}"
-            BeginEdit="PropertiesEditor_BeginEdit" 
-            EndEdit="PropertiesEditor_EndEdit">
+                Target="{Binding ElementName=list,Path=SelectedValue}"
+                BeginEdit="PropertiesEditor_BeginEdit" 
+                EndEdit="PropertiesEditor_EndEdit">
         </c:PropertiesEditor>
     </Grid>
 </UserControl>

--- a/SinTachiePlugin/Parts/PartsListController.xaml.cs
+++ b/SinTachiePlugin/Parts/PartsListController.xaml.cs
@@ -19,6 +19,12 @@ using UserControl = System.Windows.Controls.UserControl;
 using Path = System.IO.Path;
 using YukkuriMovieMaker.Controls;
 using System.Windows.Forms;
+using Clipboard = System.Windows.Clipboard;
+using Newtonsoft.Json;
+using System.Reflection;
+using System.Windows.Controls.Primitives;
+using Point = System.Windows.Point;
+using System.Reflection.Emit;
 
 namespace SinTachiePlugin.Parts
 {
@@ -82,6 +88,62 @@ namespace SinTachiePlugin.Parts
             if (DataContext is PartsListControllerViewModel viewModel)
             {
                 viewModel.SelectedTreeViewItem = e.NewValue; // ViewModelに設定
+            }
+        }
+
+        private void Scissors_Selected(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is PartsListControllerViewModel viewModel)
+            {
+                viewModel.ScissorsFunc();
+            }
+        }
+
+        private void Copy_Selected(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is PartsListControllerViewModel viewModel)
+            {
+                viewModel.CopyFunc();
+            }
+        }
+
+        private void Paste_Selected(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is PartsListControllerViewModel viewModel)
+            {
+                viewModel.PasteFunc();
+            }
+        }
+
+        private void Duplication_Selected(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is PartsListControllerViewModel viewModel)
+            {
+                viewModel.DuplicationFunc();
+            }
+        }
+
+        private void Remove_Selected(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is PartsListControllerViewModel viewModel)
+            {
+                viewModel.RemoveFunc();
+            }
+        }
+
+        private void list_MouseRightButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is PartsListControllerViewModel viewModel)
+            {
+                viewModel.EditPopupIsOpen = true;
+            }
+        }
+
+        private void PartBlockUI_RightMouseButtonUp(object sender, EventArgs e)
+        {
+            if (DataContext is PartsListControllerViewModel viewModel)
+            {
+                viewModel.EditPopupIsOpen = true;
             }
         }
     }

--- a/SinTachiePlugin/Parts/PartsListController.xaml.cs
+++ b/SinTachiePlugin/Parts/PartsListController.xaml.cs
@@ -91,7 +91,7 @@ namespace SinTachiePlugin.Parts
             }
         }
 
-        private void Scissors_Selected(object sender, RoutedEventArgs e)
+        private void Scissors_Clicked(object sender, RoutedEventArgs e)
         {
             if (DataContext is PartsListControllerViewModel viewModel)
             {
@@ -99,7 +99,7 @@ namespace SinTachiePlugin.Parts
             }
         }
 
-        private void Copy_Selected(object sender, RoutedEventArgs e)
+        private void Copy_Clicked(object sender, RoutedEventArgs e)
         {
             if (DataContext is PartsListControllerViewModel viewModel)
             {
@@ -107,7 +107,7 @@ namespace SinTachiePlugin.Parts
             }
         }
 
-        private void Paste_Selected(object sender, RoutedEventArgs e)
+        private void Paste_Clicked(object sender, RoutedEventArgs e)
         {
             if (DataContext is PartsListControllerViewModel viewModel)
             {
@@ -115,7 +115,7 @@ namespace SinTachiePlugin.Parts
             }
         }
 
-        private void Duplication_Selected(object sender, RoutedEventArgs e)
+        private void Duplication_Clicked(object sender, RoutedEventArgs e)
         {
             if (DataContext is PartsListControllerViewModel viewModel)
             {
@@ -123,27 +123,11 @@ namespace SinTachiePlugin.Parts
             }
         }
 
-        private void Remove_Selected(object sender, RoutedEventArgs e)
+        private void Remove_Clicked(object sender, RoutedEventArgs e)
         {
             if (DataContext is PartsListControllerViewModel viewModel)
             {
                 viewModel.RemoveFunc();
-            }
-        }
-
-        private void list_MouseRightButtonUp(object sender, MouseButtonEventArgs e)
-        {
-            if (DataContext is PartsListControllerViewModel viewModel)
-            {
-                viewModel.EditPopupIsOpen = true;
-            }
-        }
-
-        private void PartBlockUI_RightMouseButtonUp(object sender, EventArgs e)
-        {
-            if (DataContext is PartsListControllerViewModel viewModel)
-            {
-                viewModel.EditPopupIsOpen = true;
             }
         }
     }

--- a/SinTachiePlugin/Parts/PartsListControllerViewModel.cs
+++ b/SinTachiePlugin/Parts/PartsListControllerViewModel.cs
@@ -45,7 +45,7 @@ namespace SinTachiePlugin.Parts
         }
         SinTachieCharacterParameter? characterParameter;
       
-        protected override void SetProparties()
+        public override void SetProperties()
         {
             foreach (var property in properties)
                 property.SetValue(Parts);

--- a/SinTachiePlugin/Parts/PartsListControllerViewModel.cs
+++ b/SinTachiePlugin/Parts/PartsListControllerViewModel.cs
@@ -51,6 +51,14 @@ namespace SinTachiePlugin.Parts
                 property.SetValue(Parts);
         }
 
+        public override void CopyToOtherItems()
+        {
+            //現在のアイテムの内容を他のアイテムにコピーする
+            var otherProperties = properties.Skip(1);
+            foreach (var property in otherProperties)
+                property.SetValue(Parts.Select(x => new PartBlock(x)).ToImmutableList());
+        }
+
         private void CharacterParameterChanged(object sender, PropertyChangedEventArgs e)
         {
             SetRoot();

--- a/SinTachiePlugin/Parts/PartsListControllerViewModel.cs
+++ b/SinTachiePlugin/Parts/PartsListControllerViewModel.cs
@@ -21,7 +21,7 @@ using YukkuriMovieMaker.Settings;
 
 namespace SinTachiePlugin.Parts
 {
-    public class PartsListControllerViewModel(ItemProperty[] properties) : PartsListControllerViewModelBase(properties)
+    public partial class PartsListControllerViewModel(ItemProperty[] properties) : PartsListControllerViewModelBase(properties)
     {
         public SinTachieCharacterParameter? CharacterParameter
         {

--- a/SinTachiePlugin/Parts/PartsListControllerViewModelBase.cs
+++ b/SinTachiePlugin/Parts/PartsListControllerViewModelBase.cs
@@ -19,7 +19,7 @@ namespace SinTachiePlugin.Parts
     public abstract class PartsListControllerViewModelBase : Bindable, INotifyPropertyChanged, IPropertyEditorControl, IDisposable
     {
         readonly INotifyPropertyChanged item;
-        protected readonly ItemProperty[] properties;
+        readonly ItemProperty[] properties;
         static PartBlock? clipedBlock = null;
 
         public event EventHandler? BeginEdit;
@@ -85,7 +85,7 @@ namespace SinTachiePlugin.Parts
                 Parts = Parts.Insert(tmpSelectedIndex, new PartBlock(clipedBlock));
                 SelectedPartIndex = tmpSelectedIndex;
             }
-            SetProparties();
+            SetProperties();
             EndEdit?.Invoke(this, EventArgs.Empty);
         }
 
@@ -164,13 +164,13 @@ namespace SinTachiePlugin.Parts
                             {
                                 tmpSelectedIndex = Parts.Count;
                                 Parts = Parts.Add(new PartBlock(partImagePath, tag, tags.ToArray()));
-                                SetProparties();
+                                SetProperties();
                             }
                             else
                             {
                                 tmpSelectedIndex = SelectedPartIndex;
                                 Parts = Parts.Insert(tmpSelectedIndex, new PartBlock(partImagePath, tag, tags.ToArray()));
-                                SetProparties();
+                                SetProperties();
                             }
                             EndEdit?.Invoke(this, EventArgs.Empty);
                             SelectedPartIndex = tmpSelectedIndex;
@@ -251,7 +251,7 @@ namespace SinTachiePlugin.Parts
                                 Parts = Parts.Insert(tmpSelectedIndex, new PartBlock("", tag, tags.ToArray()));
                                 SelectedPartIndex = tmpSelectedIndex;
                             }
-                            SetProparties();
+                            SetProperties();
                             EndEdit?.Invoke(this, EventArgs.Empty);
                             PartsPopupIsOpen = false;
                         }
@@ -278,7 +278,7 @@ namespace SinTachiePlugin.Parts
                     var clone = Parts[SelectedPartIndex];
                     Parts = Parts.RemoveAt(tmpSelectedIndex);
                     Parts = Parts.Insert(tmpSelectedIndex - 1, clone);
-                    SetProparties();
+                    SetProperties();
                     EndEdit?.Invoke(this, EventArgs.Empty);
                     SelectedPartIndex = tmpSelectedIndex - 1;
                 });
@@ -292,7 +292,7 @@ namespace SinTachiePlugin.Parts
                     var clone = parts[SelectedPartIndex];
                     Parts = Parts.RemoveAt(tmpSelectedIndex);
                     Parts = Parts.Insert(tmpSelectedIndex + 1, clone);
-                    SetProparties();
+                    SetProperties();
                     EndEdit?.Invoke(this, EventArgs.Empty);
                     SelectedPartIndex = tmpSelectedIndex + 1;
                 });
@@ -344,7 +344,7 @@ namespace SinTachiePlugin.Parts
                         SinTachieDialog.ShowError("選択されたブロックを取得できません。", clsName, mthName);
                         return;
                     }
-                    SetProparties();
+                    SetProperties();
                     selected.ReloadDefault();
                     EndEdit?.Invoke(this, EventArgs.Empty);
                 });
@@ -378,7 +378,7 @@ namespace SinTachiePlugin.Parts
         {
             var tmpSelectedIndex = SelectedPartIndex;
             Parts = Parts.RemoveAt(tmpSelectedIndex);
-            SetProparties();
+            SetProperties();
             if (Parts.Count > 0) SelectedPartIndex = Math.Min(tmpSelectedIndex, Parts.Count - 1);
             else SelectedPartIndex = -1;
         }
@@ -397,10 +397,10 @@ namespace SinTachiePlugin.Parts
                 Parts = Parts.Insert(tmpSelectedIndex, new PartBlock(copied));
                 SelectedPartIndex = tmpSelectedIndex;
             }
-            SetProparties();
+            SetProperties();
         }
 
-        protected abstract void SetProparties();
+        public abstract void SetProperties();
 
         private void Item_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {

--- a/SinTachiePlugin/Properties/launchSettings.json
+++ b/SinTachiePlugin/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "SinTachiePlugin": {
       "commandName": "Project"
     },
-    "プロファイル 1": {
+    "YMM4で動かす": {
       "commandName": "Executable",
       "executablePath": "C:\\Users\\shinm\\Desktop\\YukkuriMovieMaker_v4\\YukkuriMovieMaker.exe"
     }

--- a/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShape.xaml
+++ b/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShape.xaml
@@ -23,7 +23,7 @@
             <Border Grid.Column="0" BorderBrush="#FF484848" Margin="2,0,0,0" BorderThickness="1" HorizontalAlignment="Left" VerticalAlignment="Center">
                 <TextBlock Text="素材の場所" Margin="2,2,2,2" HorizontalAlignment="Left"/>
             </Border>
-            <c:DirectorySelector  Margin="2,0,0,0" Grid.Column="1" Value="{Binding Root, Mode=TwoWay}" BeginEdit="PropertiesEditor_BeginEdit" EndEdit="PropertiesEditor_EndEdit"/>
+            <c:DirectorySelector  Margin="2,0,0,0" Grid.Column="1" Value="{Binding Root, Mode=TwoWay}" BeginEdit="PropertiesEditor_BeginEdit"  EndEdit="PropertiesEditor_EndEdit"/>
         </Grid>
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
@@ -34,7 +34,7 @@
                      Name="list" ScrollViewer.CanContentScroll="False">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
-                        <local1:PartBlockUI BeginEdit="PropertiesEditor_BeginEdit" EndEdit="PropertiesEditor_EndEdit"/>
+                        <local1:PartBlockUI BeginEdit="PropertiesEditor_BeginEdit" EndEdit="DirectorySelector_EndEdit"/>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
                 <ListBox.ContextMenu>

--- a/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShape.xaml
+++ b/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShape.xaml
@@ -10,7 +10,7 @@
              d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{d:DesignInstance Type={x:Type local:PartsListControllerForShapeViewModel}}">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="26"/>
+            <RowDefinition Height="auto"/>
             <RowDefinition Height="210"/>
             <RowDefinition Height="70"/>
             <RowDefinition Height="auto"/>

--- a/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShape.xaml
+++ b/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShape.xaml
@@ -30,19 +30,23 @@
                 <ColumnDefinition />
                 <ColumnDefinition Width="26"/>
             </Grid.ColumnDefinitions>
-            <ListBox Grid.Column="0" HorizontalContentAlignment="Stretch" ItemsSource="{Binding Path=Parts}" SelectedIndex="{Binding SelectedIndex, Mode=TwoWay}" Name="list" ScrollViewer.CanContentScroll="False">
-                <ListBox.ItemContainerStyle>
-                    <Style TargetType="ListBoxItem">
-                        <Setter Property="Height" Value="60"/>
-                    </Style>
-                </ListBox.ItemContainerStyle>
+            <ListBox Grid.Column="0" HorizontalContentAlignment="Stretch" ItemsSource="{Binding Path=Parts}" SelectedIndex="{Binding SelectedPartIndex, Mode=TwoWay}"
+                     Name="list" ScrollViewer.CanContentScroll="False" MouseRightButtonUp="list_MouseRightButtonUp">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
-                        <local1:PartBlockUI BeginEdit="PropertiesEditor_BeginEdit" EndEdit="PropertiesEditor_EndEdit"/>
+                        <local1:PartBlockUI BeginEdit="PropertiesEditor_BeginEdit" EndEdit="PropertiesEditor_EndEdit" RightMouseButtonUp="PartBlockUI_RightMouseButtonUp"/>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>
-
+            <Popup IsOpen="{Binding EditPopupIsOpen}" Placement="MousePoint"  StaysOpen="False" Panel.ZIndex="100" >
+                <ListBox SelectedIndex="{Binding BottunIndex}">
+                    <ListBoxItem Content="切り取り" IsEnabled="{Binding ScissorsEnable}" Selected="Scissors_Selected"/>
+                    <ListBoxItem Content="コピー" IsEnabled="{Binding CopyEnable}" Selected="Copy_Selected"/>
+                    <ListBoxItem Content="貼り付け" IsEnabled="{Binding PasteEnable}" Selected="Paste_Selected"/>
+                    <ListBoxItem Content="複製" IsEnabled="{Binding DuplicationEnable}" Selected="Duplication_Selected"/>
+                    <ListBoxItem Content="削除" IsEnabled="{Binding RemoveEnable}" Selected="Remove_Selected"/>
+                </ListBox>
+            </Popup>
             <Grid Grid.Column="1">
                 <Grid>
                     <Grid.RowDefinitions>
@@ -50,15 +54,13 @@
                         <RowDefinition Height="26"/>
                         <RowDefinition Height="26"/>
                         <RowDefinition Height="26"/>
-                        <RowDefinition Height="26"/>
                     </Grid.RowDefinitions>
                     <Button Grid.Row="0" Content="╋" Command="{Binding AddCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" ToolTip="「追加するパーツ」で選択している名前のパーツが追加されます。"/>
                     <Button Grid.Row="1" Content="━" Command="{Binding RemoveCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" ToolTip="選択されているパーツを取り除きます。"/>
-                    <Button Grid.Row="2" Content="複" Command="{Binding DuplicationCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" ToolTip="選択されているパーツを複製します。"/>
-                    <Button Grid.Row="3" Content="▲" Command="{Binding MoveUpCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" ToolTip="選択されているパーツを一つ上のパーツと入れ替えます。"/>
-                    <Button Grid.Row="4" Content="▼" Command="{Binding MoveDownCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" ToolTip="選択されているパーツを一つ下のパーツと入れ替えます。"/>
+                    <Button Grid.Row="2" Content="▲" Command="{Binding MoveUpCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" ToolTip="選択されているパーツを一つ上のパーツと入れ替えます。"/>
+                    <Button Grid.Row="3" Content="▼" Command="{Binding MoveDownCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" ToolTip="選択されているパーツを一つ下のパーツと入れ替えます。"/>
                 </Grid>
-                <Popup IsOpen="{Binding PopupIsOpen}" Placement="Left" StaysOpen="False" VerticalAlignment="Top" >
+                <Popup IsOpen="{Binding PartsPopupIsOpen}" Placement="Left" StaysOpen="False" VerticalAlignment="Top" >
                     <ScrollViewer MaxHeight="300" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
                         <TreeView Panel.ZIndex="100" ItemsSource ="{Binding PartNameTree}" SelectedItemChanged="TreeView_SelectedItemChanged">
                             <TreeView.ItemTemplate>
@@ -83,21 +85,20 @@
                         <RowDefinition Height="26"/>
                     </Grid.RowDefinitions>
 
-                        <!-- 選択されたブロックのデフォルト値を編集するエリア -->
-                        <Label Grid.Row="0" Content="デフォルト設定" HorizontalAlignment="Left" Margin="4,4,0,0" VerticalAlignment="Top" Padding="0,0,0,0"/>
-                        <Grid Grid.Row="1" Margin="0,0,8,0">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition/>
-                                <ColumnDefinition/>
-                                <ColumnDefinition/>
-                            </Grid.ColumnDefinitions>
-                            <Button Grid.Column="0" Command="{Binding WriteDefaultCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" Content="保存" ToolTip="選択されているパーツが指定している画像ファイルに、現在のパーツパラメータ情報をデフォルトとして記録します。&#xa;(stpiファイルが生成されます。)"/>
-                            <Button Grid.Column="1" Command="{Binding DeleteDefaultCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" Content="削除" ToolTip="選択されているパーツが指定している画像ファイルから、デフォルトのパラメータ情報を取り消します。&#xa;(stpiファイル自体は削除されません。)"/>
-                            <Button Grid.Column="2" Command="{Binding ReloadDefaultCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" Content="リロード" ToolTip="選択されているパーツが指定している画像ファイルから、デフォルトのパラメータ情報を読み取り、現在の全パラメータを自動編集します。"/>
-                        </Grid>
+                    <!-- 選択されたブロックのデフォルト値を編集するエリア -->
+                    <Label Grid.Row="0" Content="デフォルト設定" HorizontalAlignment="Left" Margin="4,4,0,0" VerticalAlignment="Top" Padding="0,0,0,0"/>
+                    <Grid Grid.Row="1" Margin="0,0,8,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition/>
+                            <ColumnDefinition/>
+                            <ColumnDefinition/>
+                        </Grid.ColumnDefinitions>
+                        <Button Grid.Column="0" Command="{Binding WriteDefaultCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" Content="保存" ToolTip="選択されているパーツが指定している画像ファイルに、現在のパーツパラメータ情報をデフォルトとして記録します。&#xa;(stpiファイルが生成されます。)"/>
+                        <Button Grid.Column="1" Command="{Binding DeleteDefaultCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" Content="削除" ToolTip="選択されているパーツが指定している画像ファイルから、デフォルトのパラメータ情報を取り消します。&#xa;(stpiファイル自体は削除されません。)"/>
+                        <Button Grid.Column="2" Command="{Binding ReloadDefaultCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" Content="リロード" ToolTip="選択されているパーツが指定している画像ファイルから、デフォルトのパラメータ情報を読み取り、現在の全パラメータを自動編集します。"/>
                     </Grid>
                 </Grid>
-            </WrapPanel>
+            </Grid>
         </Grid>
         <c:PropertiesEditor 
             Grid.Row="3"

--- a/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShape.xaml
+++ b/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShape.xaml
@@ -31,22 +31,22 @@
                 <ColumnDefinition Width="26"/>
             </Grid.ColumnDefinitions>
             <ListBox Grid.Column="0" HorizontalContentAlignment="Stretch" ItemsSource="{Binding Path=Parts}" SelectedIndex="{Binding SelectedPartIndex, Mode=TwoWay}"
-                     Name="list" ScrollViewer.CanContentScroll="False" MouseRightButtonUp="list_MouseRightButtonUp">
+                     Name="list" ScrollViewer.CanContentScroll="False">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
-                        <local1:PartBlockUI BeginEdit="PropertiesEditor_BeginEdit" EndEdit="PropertiesEditor_EndEdit" RightMouseButtonUp="PartBlockUI_RightMouseButtonUp"/>
+                        <local1:PartBlockUI BeginEdit="PropertiesEditor_BeginEdit" EndEdit="PropertiesEditor_EndEdit"/>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
+                <ListBox.ContextMenu>
+                    <ContextMenu  IsOpen="{Binding ContextMenuIsOpen}">
+                        <MenuItem Header="切り取り" IsEnabled="{Binding SomeBlockSelected}" Click ="Scissors_Clicked"/>
+                        <MenuItem Header="コピー" IsEnabled="{Binding SomeBlockSelected}" Click="Copy_Clicked"/>
+                        <MenuItem Header="貼り付け" IsEnabled="{Binding PasteEnable}" Click="Paste_Clicked"/>
+                        <MenuItem Header="複製" IsEnabled="{Binding SomeBlockSelected}" Click="Duplication_Clicked"/>
+                        <MenuItem Header="削除" IsEnabled="{Binding SomeBlockSelected}" Click="Remove_Clicked"/>
+                    </ContextMenu>
+                </ListBox.ContextMenu>
             </ListBox>
-            <Popup IsOpen="{Binding EditPopupIsOpen}" Placement="MousePoint"  StaysOpen="False" Panel.ZIndex="100" >
-                <ListBox SelectedIndex="{Binding BottunIndex}">
-                    <ListBoxItem Content="切り取り" IsEnabled="{Binding ScissorsEnable}" Selected="Scissors_Selected"/>
-                    <ListBoxItem Content="コピー" IsEnabled="{Binding CopyEnable}" Selected="Copy_Selected"/>
-                    <ListBoxItem Content="貼り付け" IsEnabled="{Binding PasteEnable}" Selected="Paste_Selected"/>
-                    <ListBoxItem Content="複製" IsEnabled="{Binding DuplicationEnable}" Selected="Duplication_Selected"/>
-                    <ListBoxItem Content="削除" IsEnabled="{Binding RemoveEnable}" Selected="Remove_Selected"/>
-                </ListBox>
-            </Popup>
             <Grid Grid.Column="1">
                 <Grid>
                     <Grid.RowDefinitions>
@@ -61,7 +61,7 @@
                     <Button Grid.Row="3" Content="▼" Command="{Binding MoveDownCommand}" CommandParameter="{Binding ElementName=list,Path=SelectedIndex}" ToolTip="選択されているパーツを一つ下のパーツと入れ替えます。"/>
                 </Grid>
                 <Popup IsOpen="{Binding PartsPopupIsOpen}" Placement="Left" StaysOpen="False" VerticalAlignment="Top" >
-                    <ScrollViewer MaxHeight="300" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
+                    <ScrollViewer MaxHeight="300" MinWidth="100" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
                         <TreeView Panel.ZIndex="100" ItemsSource ="{Binding PartNameTree}" SelectedItemChanged="TreeView_SelectedItemChanged">
                             <TreeView.ItemTemplate>
                                 <HierarchicalDataTemplate ItemsSource="{Binding Children}">

--- a/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShape.xaml.cs
+++ b/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShape.xaml.cs
@@ -108,5 +108,12 @@ namespace SinTachiePlugin.ShapePludin.PartsListControllerForShape
                 viewModel.RemoveFunc();
             }
         }
+
+        private void DirectorySelector_EndEdit(object sender, EventArgs e)
+        {
+            var vm = DataContext as PartsListControllerForShapeViewModel;
+            vm?.SetProperties();
+            EndEdit?.Invoke(this, e);
+        }
     }
 }

--- a/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShape.xaml.cs
+++ b/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShape.xaml.cs
@@ -1,18 +1,6 @@
-﻿using SinTachiePlugin.Parts;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using YukkuriMovieMaker.Commons;
 
 namespace SinTachiePlugin.ShapePludin.PartsListControllerForShape
@@ -61,9 +49,77 @@ namespace SinTachiePlugin.ShapePludin.PartsListControllerForShape
 
         private void TreeView_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
         {
-            if (DataContext is PartsListControllerViewModel viewModel)
+            if (DataContext is PartsListControllerForShapeViewModel viewModel)
             {
                 viewModel.SelectedTreeViewItem = e.NewValue; // ViewModelに設定
+            }
+        }
+
+        private void ScrollViewer_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            if (sender is ScrollViewer scrollViewer)
+            {
+                if (e.Delta > 0)
+                    scrollViewer.LineUp();
+                else
+                    scrollViewer.LineDown();
+
+                e.Handled = true;
+            }
+        }
+        private void Scissors_Selected(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is PartsListControllerForShapeViewModel viewModel)
+            {
+                viewModel.ScissorsFunc();
+            }
+        }
+
+        private void Copy_Selected(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is PartsListControllerForShapeViewModel viewModel)
+            {
+                viewModel.CopyFunc();
+            }
+        }
+
+        private void Paste_Selected(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is PartsListControllerForShapeViewModel viewModel)
+            {
+                viewModel.PasteFunc();
+            }
+        }
+
+        private void Duplication_Selected(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is PartsListControllerForShapeViewModel viewModel)
+            {
+                viewModel.DuplicationFunc();
+            }
+        }
+
+        private void Remove_Selected(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is PartsListControllerForShapeViewModel viewModel)
+            {
+                viewModel.RemoveFunc();
+            }
+        }
+
+        private void list_MouseRightButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is PartsListControllerForShapeViewModel viewModel)
+            {
+                viewModel.EditPopupIsOpen = true;
+            }
+        }
+
+        private void PartBlockUI_RightMouseButtonUp(object sender, EventArgs e)
+        {
+            if (DataContext is PartsListControllerForShapeViewModel viewModel)
+            {
+                viewModel.EditPopupIsOpen = true;
             }
         }
     }

--- a/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShape.xaml.cs
+++ b/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShape.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using SinTachiePlugin.Parts;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using YukkuriMovieMaker.Commons;
@@ -67,7 +68,8 @@ namespace SinTachiePlugin.ShapePludin.PartsListControllerForShape
                 e.Handled = true;
             }
         }
-        private void Scissors_Selected(object sender, RoutedEventArgs e)
+
+        private void Scissors_Clicked(object sender, RoutedEventArgs e)
         {
             if (DataContext is PartsListControllerForShapeViewModel viewModel)
             {
@@ -75,7 +77,7 @@ namespace SinTachiePlugin.ShapePludin.PartsListControllerForShape
             }
         }
 
-        private void Copy_Selected(object sender, RoutedEventArgs e)
+        private void Copy_Clicked(object sender, RoutedEventArgs e)
         {
             if (DataContext is PartsListControllerForShapeViewModel viewModel)
             {
@@ -83,7 +85,7 @@ namespace SinTachiePlugin.ShapePludin.PartsListControllerForShape
             }
         }
 
-        private void Paste_Selected(object sender, RoutedEventArgs e)
+        private void Paste_Clicked(object sender, RoutedEventArgs e)
         {
             if (DataContext is PartsListControllerForShapeViewModel viewModel)
             {
@@ -91,7 +93,7 @@ namespace SinTachiePlugin.ShapePludin.PartsListControllerForShape
             }
         }
 
-        private void Duplication_Selected(object sender, RoutedEventArgs e)
+        private void Duplication_Clicked(object sender, RoutedEventArgs e)
         {
             if (DataContext is PartsListControllerForShapeViewModel viewModel)
             {
@@ -99,27 +101,11 @@ namespace SinTachiePlugin.ShapePludin.PartsListControllerForShape
             }
         }
 
-        private void Remove_Selected(object sender, RoutedEventArgs e)
+        private void Remove_Clicked(object sender, RoutedEventArgs e)
         {
             if (DataContext is PartsListControllerForShapeViewModel viewModel)
             {
                 viewModel.RemoveFunc();
-            }
-        }
-
-        private void list_MouseRightButtonUp(object sender, MouseButtonEventArgs e)
-        {
-            if (DataContext is PartsListControllerForShapeViewModel viewModel)
-            {
-                viewModel.EditPopupIsOpen = true;
-            }
-        }
-
-        private void PartBlockUI_RightMouseButtonUp(object sender, EventArgs e)
-        {
-            if (DataContext is PartsListControllerForShapeViewModel viewModel)
-            {
-                viewModel.EditPopupIsOpen = true;
             }
         }
     }

--- a/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShapeViewModel.cs
+++ b/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShapeViewModel.cs
@@ -32,5 +32,17 @@ namespace SinTachiePlugin.ShapePludin.PartsListControllerForShape
             }
             Root = values.Root;
         }
+
+        public override void CopyToOtherItems()
+        {
+            //現在のアイテムの内容を他のアイテムにコピーする
+            var otherProperties = properties.Skip(1);
+            foreach (var property in otherProperties)
+                property.SetValue(new PartsOfShapeItem
+                {
+                    Parts = Parts.Select(x => new PartBlock(x)).ToImmutableList(),
+                    Root = Root,
+                });
+        }
     }
 }

--- a/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShapeViewModel.cs
+++ b/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShapeViewModel.cs
@@ -17,7 +17,7 @@ namespace SinTachiePlugin.ShapePludin.PartsListControllerForShape
 {
     public partial class PartsListControllerForShapeViewModel(ItemProperty[] properties) : PartsListControllerViewModelBase(properties)
     {
-        protected override void SetProparties()
+        public override void SetProperties()
         {
             foreach (var property in properties)
                 property.SetValue(new PartsOfShapeItem() { Root = Root, Parts = Parts });
@@ -37,12 +37,22 @@ namespace SinTachiePlugin.ShapePludin.PartsListControllerForShape
         {
             //現在のアイテムの内容を他のアイテムにコピーする
             var otherProperties = properties.Skip(1);
-            foreach (var property in otherProperties)
-                property.SetValue(new PartsOfShapeItem
+            for (int i = 0; i < properties.Count(); i++)
+            {
+                var property = properties[i];
+                if (i is 0)
                 {
-                    Parts = Parts.Select(x => new PartBlock(x)).ToImmutableList(),
-                    Root = Root,
-                });
+                    property.SetValue(new PartsOfShapeItem() { Root = Root, Parts = Parts });
+                }
+                else
+                {
+                    property.SetValue(new PartsOfShapeItem
+                    {
+                        Parts = Parts.Select(x => new PartBlock(x)).ToImmutableList(),
+                        Root = Root,
+                    });
+                }
+            }
         }
     }
 }

--- a/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShapeViewModel.cs
+++ b/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsListControllerForShapeViewModel.cs
@@ -15,7 +15,7 @@ using YukkuriMovieMaker.Settings;
 
 namespace SinTachiePlugin.ShapePludin.PartsListControllerForShape
 {
-    public class PartsListControllerForShapeViewModel(ItemProperty[] properties) : PartsListControllerViewModelBase(properties)
+    public partial class PartsListControllerForShapeViewModel(ItemProperty[] properties) : PartsListControllerViewModelBase(properties)
     {
         protected override void SetProparties()
         {

--- a/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsOfShapeItem.cs
+++ b/SinTachiePlugin/ShapePludin/PartsListControllerForShape/PartsOfShapeItem.cs
@@ -18,6 +18,6 @@ namespace SinTachiePlugin.ShapePludin.PartsListControllerForShape
         public ImmutableList<PartBlock> Parts { get => parts; set => Set(ref parts, value); }
         ImmutableList<PartBlock> parts = [];
 
-        protected override IEnumerable<IAnimatable> GetAnimatables() => Parts;
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [.. Parts];
     }
 }

--- a/SinTachiePlugin/ShapePludin/ShapeParameterOfSinTachie.cs
+++ b/SinTachiePlugin/ShapePludin/ShapeParameterOfSinTachie.cs
@@ -18,7 +18,7 @@ namespace SinTachiePlugin.ShapePludin
 {
     internal class ShapeParameterOfSinTachie(SharedDataStore? sharedData) : ShapeParameterBase(sharedData)
     {
-        [Display(Name = "描画順序", Description = "描画順序\n(アイテムを閉じると「ルート」が空になってしまうので、その都度「素材の場所」のパスをコピペして使ってください。)")]
+        [Display(Name = "描画順序")]
         [PartsListControllerForShape(PropertyEditorSize = PropertyEditorSize.FullWidth)]
         public PartsOfShapeItem PartsAndRoot { get => partsAndRoot; set => Set(ref partsAndRoot, value); }
         PartsOfShapeItem partsAndRoot = new();
@@ -42,7 +42,7 @@ namespace SinTachiePlugin.ShapePludin
             return new ShapeOfSinTachieSource(devices, this);
         }
 
-        protected override IEnumerable<IAnimatable> GetAnimatables() => PartsAndRoot.Parts;
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [PartsAndRoot];
 
         protected override void LoadSharedData(SharedDataStore store)
         {

--- a/SinTachiePlugin/SinTachiePlugin.csproj
+++ b/SinTachiePlugin/SinTachiePlugin.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<UseWPF>true</UseWPF>
 		<UseWindowsForms>true</UseWindowsForms>
-		<FileVersion>1.0.3.3</FileVersion>
+		<FileVersion>1.0.5.0</FileVersion>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 


### PR DESCRIPTION
<| 廃止 |>
「複」ボタンの廃止

<| 追加 |>
右クリックでパーツの「切り取り」「コピー」「貼り付け」「複製」「削除」をできるようにした。

<| 修正 |>
図形アイテム版で追加するアイテムを選択してもPopupが消えず、パーツブロックが追加されないバグを修正。
図形アイテム版の「素地の場所」のパスを変更してもステップとしてカウントされず、Ctr+Z / Y が無効だったバグを修正。